### PR TITLE
Persist name to local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const App: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [users, setUsers] = useState<Users>({
     [ownId]: {
-      name: '',
+      name: localStorage.getItem('name') || '',
       value: undefined,
     },
   });
@@ -48,6 +48,12 @@ const App: React.FC = () => {
   const setData = (name: string, value: string | undefined) => {
     sendData(name, value);
     setUsers(users => ({ ...users, [ownId]: { name, value } }));
+  };
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const name = event.target.value;
+    localStorage.setItem('name', name);
+    setData(name, value);
   };
 
   const reset = () => {
@@ -129,7 +135,7 @@ const App: React.FC = () => {
           <input
             style={{ marginLeft: 16 }}
             value={name}
-            onChange={event => setData(event.target.value, value)}
+            onChange={handleNameChange}
           ></input>
         </label>
       </div>


### PR DESCRIPTION
Persist name to local storage: the user doesn't need to enter the name after every reload again.